### PR TITLE
fix: Usar instancia singleton de HealthCalcImpl en los tests

### DIFF
--- a/java-project-healthcalc/src/test/java/healthcalc/BDD/BMISteps.java
+++ b/java-project-healthcalc/src/test/java/healthcalc/BDD/BMISteps.java
@@ -22,7 +22,7 @@ public class BMISteps {
 
     @Given("la calculadora de salud debe estar iniciada para BMI")
     public void la_calculadora_de_salud_debe_estar_iniciada_para_BMI() {
-        this.calculator = new HealthCalcImpl();
+        this.calculator = HealthCalcImpl.getInstance();
     }
 
     @Given("el usuario ha seleccionado la métrica de BMI para calcular")

--- a/java-project-healthcalc/src/test/java/healthcalc/BDD/BSASteps.java
+++ b/java-project-healthcalc/src/test/java/healthcalc/BDD/BSASteps.java
@@ -19,7 +19,7 @@ public class BSASteps {
 
     @Given("la calculadora de salud está iniciada")
     public void la_calculadora_de_salud_esta_iniciada() {
-        calculator = new HealthCalcImpl();
+        calculator = HealthCalcImpl.getInstance();
     }
 
     @Given("el usuario ha seleccionado la métrica BSA para calcular")

--- a/java-project-healthcalc/src/test/java/healthcalc/BDD/IBWSteps.java
+++ b/java-project-healthcalc/src/test/java/healthcalc/BDD/IBWSteps.java
@@ -11,7 +11,7 @@ import io.cucumber.java.en.When;
 
 public class IBWSteps {
 
-    private HealthCalc calculator = new HealthCalcImpl();
+    private HealthCalc calculator = HealthCalcImpl.getInstance();
     private double height;
     private char gender;
     private double result;

--- a/java-project-healthcalc/src/test/java/healthcalc/BMITest.java
+++ b/java-project-healthcalc/src/test/java/healthcalc/BMITest.java
@@ -28,7 +28,7 @@ public class BMITest {
 
 	@BeforeEach
 	void setUp() {
-		healthCalc = new HealthCalcImpl();
+		healthCalc = HealthCalcImpl.getInstance();
 	}
 
     @Nested

--- a/java-project-healthcalc/src/test/java/healthcalc/BSATest.java
+++ b/java-project-healthcalc/src/test/java/healthcalc/BSATest.java
@@ -24,7 +24,7 @@ public class BSATest {
 
     @BeforeEach
     void setUp() {
-        healthCalc = new HealthCalcImpl();
+        healthCalc = HealthCalcImpl.getInstance();
     }
 
     @Nested

--- a/java-project-healthcalc/src/test/java/healthcalc/IBWTest.java
+++ b/java-project-healthcalc/src/test/java/healthcalc/IBWTest.java
@@ -24,7 +24,7 @@ public class IBWTest {
 
     @BeforeEach
     void setUp() {
-        healthCalc = new HealthCalcImpl();
+        healthCalc = HealthCalcImpl.getInstance();
     }
     
     @Nested


### PR DESCRIPTION
Hemos cambiado los test para que cuadre con el patrón Singleton. Así cuadra todo y no hay errores, podemos probar los test.